### PR TITLE
Optimise layout and improve design

### DIFF
--- a/src/CalcButton.qml
+++ b/src/CalcButton.qml
@@ -38,10 +38,11 @@ MouseArea {
             id: shade
 
             anchors.centerIn: parent
+            anchors.verticalCenterOffset: parent.height * .02
             width: Math.max(parent.width, parent.height)
             height: width
             radius: width / 2
-            color: "#E83F6F"
+            color: "#19381F"
             opacity: 0
             z: parent.z - 1
         }
@@ -55,10 +56,10 @@ MouseArea {
            when: button.pressed === true
 
            PropertyChanges { target: button; z: 2 }
-           PropertyChanges { target: shade; opacity: 1 }
+           PropertyChanges { target: shade; opacity: .9 }
            PropertyChanges { target: shade; scale: 1 }
-           PropertyChanges { target: buttonText; font.pixelSize: parent.width * 1.2 }
-           PropertyChanges { target: buttonText; font.styleName: "Black" }
+           PropertyChanges { target: buttonText; font.pixelSize: parent.width * 1.1 }
+           PropertyChanges { target: buttonText; font.styleName: "Bold" }
            PropertyChanges {
                target: buttonText
                anchors.verticalCenterOffset:
@@ -94,19 +95,19 @@ MouseArea {
                anchors.horizontalCenterOffset:
                    switch (buttonText.text) {
                        case "-": {
-                           -button.height * 0.7
+                           -button.height * .7
                            break
                        }
                        case "\u00f7": {
-                           button.height * 0.7
+                           button.height * .7
                            break
                        }
                        case "\u00d7": {
-                           button.height * 0.3
+                           button.height * .3
                            break
                        }
                        case "+": {
-                           -button.height * 0.3
+                           -button.height * .3
                            break
                        }
                        default: {

--- a/src/CalcButton.qml
+++ b/src/CalcButton.qml
@@ -1,5 +1,6 @@
 /*
- * Copyright (C) 2015 - Florent Revest <revestflo@gmail.com>
+ * Copyright (C) 2021 - Timo Könnecke <github.com/eLtMosen>
+*                2015 - Florent Revest <revestflo@gmail.com>
  *               2011 - Nokia Corporation and/or its subsidiary(-ies).
  *
  * This program is free software: you can redistribute it and/or modify
@@ -27,22 +28,22 @@ MouseArea {
 
     Label {
         id: buttonText
+
         anchors.centerIn: parent
         font.pixelSize: parent.width > parent.height ? parent.height * .7 : parent.width * .7
-        style: Text.Sunken; styleColor: Qt.darker(color, 1.2); smooth: true
+        smooth: true
         clip: false
 
         Rectangle {
             id: shade
-            anchors.centerIn: parent;
+
+            anchors.centerIn: parent
             width: Math.max(parent.width, parent.height)
             height: width
-            radius: width/2;
-            color: "#618404";
+            radius: width / 2
+            color: "#E83F6F"
             opacity: 0
-            z: parent.z-1
-            border.width: 1
-            border.color: "#517008"
+            z: parent.z - 1
         }
     }
 
@@ -50,12 +51,71 @@ MouseArea {
 
     states: [
        State {
-           name: "pressed"; when: button.pressed == true
-           PropertyChanges { target: shade; opacity: 1.0 }
-           PropertyChanges { target: shade; scale: 2.0 }
-           PropertyChanges { target: buttonText; anchors.verticalCenterOffset: -button.height }
-           PropertyChanges { target: button; z: 1 }
-       }
+           name: "pressed"
+           when: button.pressed === true
+
+           PropertyChanges { target: button; z: 2 }
+           PropertyChanges { target: shade; opacity: 1 }
+           PropertyChanges { target: shade; scale: 1 }
+           PropertyChanges { target: buttonText; font.pixelSize: parent.width * 1.2 }
+           PropertyChanges { target: buttonText; font.styleName: "Black" }
+           PropertyChanges {
+               target: buttonText
+               anchors.verticalCenterOffset:
+                   switch (buttonText.text) {
+                       case "-": {
+                           -button.height * 1.14
+                           break
+                       }
+                       case "\u00f7": {
+                           -button.height * 1.14
+                           break
+                       }
+                       case "7": {
+                           -button.height * 1.1
+                           break
+                       }
+                       case "8": {
+                           -button.height * 1.2
+                           break
+                       }
+                       case "9": {
+                           -button.height * 1.1
+                           break
+                       }
+                       default: {
+                           -button.height * 1.5
+                           break
+                       }
+                   }
+           }
+           PropertyChanges {
+               target: buttonText
+               anchors.horizontalCenterOffset:
+                   switch (buttonText.text) {
+                       case "-": {
+                           -button.height * 0.7
+                           break
+                       }
+                       case "\u00f7": {
+                           button.height * 0.7
+                           break
+                       }
+                       case "\u00d7": {
+                           button.height * 0.3
+                           break
+                       }
+                       case "+": {
+                           -button.height * 0.3
+                           break
+                       }
+                       default: {
+                           0
+                           break
+                       }
+                   }
+           }
+        }
     ]
 
     transitions: [
@@ -63,30 +123,29 @@ MouseArea {
             from: ""
             to: "pressed"
             NumberAnimation {
-                properties: "z,scale,anchors.verticalCenterOffset";
-                easing.type: Easing.OutExpo;
-                duration: 50
+                properties: "z,scale,anchors.verticalCenterOffset,anchors.horizontalCenterOffset,font.pixelSize"
+                easing.type: Easing.OutExpo
+                duration: 30
             }
             NumberAnimation {
-               properties: "opacity";
-               easing.type: Easing.OutExpo;
-               duration: 100
+                properties: "opacity"
+                easing.type: Easing.OutExpo
+                duration: 40
             }
         },
         Transition {
             from: "pressed"
             to: ""
             NumberAnimation {
-               properties: "z,scale,anchors.verticalCenterOffset";
-               easing.type: Easing.OutExpo;
-               duration: 200
+                properties: "z,scale,anchors.verticalCenterOffset,anchors.horizontalCenterOffset,font.pixelSize"
+                easing.type: Easing.InExpo
+                duration: 60
             }
             NumberAnimation {
-               properties: "opacity";
-               easing.type: Easing.OutExpo;
-               duration: 300
+                properties: "opacity"
+                easing.type: Easing.InExpo
+                duration: 80
             }
         }
     ]
 }
-

--- a/src/Display.qml
+++ b/src/Display.qml
@@ -1,5 +1,6 @@
 /*
- * Copyright (C) 2015 - Florent Revest <revestflo@gmail.com>
+ * Copyright (C) 2021 - Timo Könnecke <github.com/eLtMosen>
+ *               2015 - Florent Revest <revestflo@gmail.com>
  *               2011 - Nokia Corporation and/or its subsidiary(-ies).
  *
  * This program is free software: you can redistribute it and/or modify
@@ -21,42 +22,77 @@ import org.asteroid.controls 1.0
 import org.asteroid.utils 1.0
 import "calculator.js" as CalcEngine
 
-Label {
+Text {
     id: displayText
-    text: calcwindow.displayText.length > 0 ? calcwindow.displayText : calcwindow.displayPrevious
-    smooth: true; font.bold: true
-    anchors.leftMargin: Dims.w(7)
-    anchors.rightMargin: Dims.w(7)
-    Component.onCompleted: refitText()
+
+    property string displayTextLength: calcwindow.displayText.length > 0 ? calcwindow.displayText : calcwindow.displayPrevious
+    property int minimumSize: Dims.l(9)
+
+    anchors {
+        leftMargin: Dims.w(9)
+        rightMargin: Dims.w(9)
+    }
+    color: "#ff84E6F8"
+    font.styleName: "ExtraCondensed"
+    verticalAlignment: Text.AlignBottom
     horizontalAlignment: DeviceInfo.hasRoundScreen ? Text.AlignHCenter : Text.AlignRight
-    verticalAlignment: Text.AlignVCenter
 
-    property int minimumSize: Dims.l(15)
-
+    onDisplayTextLengthChanged: refitText()
+    Component.onCompleted: refitText()
     onWidthChanged: refitText()
     onHeightChanged: refitText()
     onTextChanged: refitText()
 
     function refitText() {
-        if (paintedHeight == -1 || paintedWidth == -1)
-            return
-
-        while (paintedWidth > width || paintedHeight > height) {
-            if (--font.pixelSize <= minimumSize || font.pixelSize <= 0)
-                break
+        switch (displayTextLength.length) {
+            case 0:
+            case 1:
+            case 2:
+            case 3:
+            case 4:
+            case 5: {
+                font.pixelSize = Dims.l(15)
+                return
+            }
+            case 6: {
+                font.pixelSize = Dims.l(14)
+                return
+            }
+            case 7: {
+                font.pixelSize = Dims.l(13)
+                return
+            }
+            case 8: {
+                font.pixelSize = Dims.l(12.5)
+                return
+            }
+            case 9: {
+                font.pixelSize = Dims.l(12)
+                return
+            }
+            case 10:
+            case 11: {
+                font.pixelSize = Dims.l(11)
+                return
+            }
+            case 12: {
+                font.pixelSize = Dims.l(10.5)
+                return
+            }
+            case 13: {
+                font.pixelSize = Dims.l(10)
+                return
+            }
+            case 14: {
+                font.pixelSize = Dims.l(9.5)
+                return
+            }
+            default: {
+                font.pixelSize = Dims.l(9)
+                return
+            }
         }
-
-        while (paintedWidth < width && paintedHeight < height) {
-            font.pixelSize++
-
-        }
-
-        // sanity cap
-        if (font.pixelSize >= Dims.l(40)) {
-            font.pixelSize = Dims.l(40)
-            return
-        }
-
-        font.pixelSize--
     }
+
+    text: displayTextLength
 }

--- a/src/Display.qml
+++ b/src/Display.qml
@@ -22,7 +22,7 @@ import org.asteroid.controls 1.0
 import org.asteroid.utils 1.0
 import "calculator.js" as CalcEngine
 
-Text {
+Label {
     id: displayText
 
     property string displayTextLength: calcwindow.displayText.length > 0 ? calcwindow.displayText : calcwindow.displayPrevious
@@ -32,8 +32,7 @@ Text {
         leftMargin: Dims.w(9)
         rightMargin: Dims.w(9)
     }
-    color: "#ff84E6F8"
-    font.styleName: "ExtraCondensed"
+    font.styleName: "ExtraCondensed Medium"
     verticalAlignment: Text.AlignBottom
     horizontalAlignment: DeviceInfo.hasRoundScreen ? Text.AlignHCenter : Text.AlignRight
 

--- a/src/calculator.js
+++ b/src/calculator.js
@@ -135,4 +135,3 @@ function disabled(op) {
         currentText ="0"
     }
 }
-

--- a/src/main.qml
+++ b/src/main.qml
@@ -70,15 +70,15 @@ Application {
                 id: displaySpacer
 
                 z: -1
-                anchors {bottom: parent.bottom
+                anchors {
+                    bottom: parent.bottom
                     left: parent.left
                     right: parent.right
                     leftMargin: -Dims.w(8)
                     rightMargin: -Dims.w(8)
                 }
                 height: content.height/4
-                color: "#aa000000"
-
+                color: "#bb19381F"
             }
 
             MouseArea {
@@ -122,7 +122,7 @@ Application {
             CalcButton { width: grid.w; height: grid.h; operation: "3"; }
             CalcButton { width: grid.w; height: grid.h; operation: "="; }
 
-            Text { text: " " }
+            Item { width: grid.w; height: width; }
             CalcButton { width: grid.w; height: grid.h; operation: "."; }
             CalcButton { width: grid.w; height: grid.h; operation: "0"; }
             CalcButton { width: grid.w; height: grid.h; operation: CalcEngine.leftArrow }

--- a/src/main.qml
+++ b/src/main.qml
@@ -1,5 +1,6 @@
 /*
- * Copyright (C) 2015 - Florent Revest <revestflo@gmail.com>
+ * Copyright (C) 2021 - Timo Könnecke <github.com/eLtMosen>
+ *               2015 - Florent Revest <revestflo@gmail.com>
  *               2011 - Nokia Corporation and/or its subsidiary(-ies).
  *
  * This program is free software: you can redistribute it and/or modify
@@ -27,9 +28,9 @@ Application {
     centerColor: "#709801"
     outerColor: "#233412"
 
-    property string displayOperation: ""
     property string displayText: "0"
     property string displayPrevious: ""
+    property string displayOperation: ""
 
     function doOp(operation) {
         CalcEngine.doOperation(operation)
@@ -40,17 +41,25 @@ Application {
 
     Item {
         id: content
-        anchors.fill: parent
-        anchors.topMargin: Dims.h(5)
-        anchors.leftMargin: DeviceInfo.hasRoundScreen ? Dims.w(9) : 0
-        anchors.rightMargin: DeviceInfo.hasRoundScreen ? Dims.w(9) : 0
-        anchors.bottomMargin: DeviceInfo.hasRoundScreen ? Dims.h(9) : 0
+
+        anchors {
+            fill: parent
+            leftMargin: DeviceInfo.hasRoundScreen ? Dims.w(8) : 0
+            rightMargin: DeviceInfo.hasRoundScreen ? Dims.w(8) : 0
+            bottomMargin: DeviceInfo.hasRoundScreen ? Dims.h(7) : 0
+        }
 
         Item {
             id: displayBackground
-            Display { id: display; anchors.fill: parent }
 
-            height: parent.height/8
+            Display {
+                id: display
+
+                anchors.fill: parent
+                anchors.bottomMargin: Dims.w(2)
+            }
+
+            height: parent.height/4
             anchors {
                 top: parent.top
                 left: parent.left
@@ -58,23 +67,35 @@ Application {
             }
 
             Rectangle {
-                height: 1
-                color: "white"
-                anchors.bottom: parent.bottom
-                anchors.left: parent.left
-                anchors.right: parent.right
-                anchors.leftMargin: Dims.w(6)
-                anchors.rightMargin: Dims.w(6)
+                id: displaySpacer
+
+                z: -1
+                anchors {bottom: parent.bottom
+                    left: parent.left
+                    right: parent.right
+                    leftMargin: -Dims.w(8)
+                    rightMargin: -Dims.w(8)
+                }
+                height: content.height/4
+                color: "#aa000000"
+
+            }
+
+            MouseArea {
+                anchors.fill: displayBackground
+                onClicked: doOp(CalcEngine.plusminus)
             }
         }
 
         Grid {
             id: grid
+
             spacing: Dims.w(2)
-            rows: 5
-            columns: 4
+            rows: 4
+            columns: 5
             anchors {
                 top: displayBackground.bottom
+                topMargin: Dims.h(1)
                 left: parent.left
                 right: parent.right
                 bottom: parent.bottom
@@ -83,32 +104,28 @@ Application {
             property real w: (grid.width / columns) - ((spacing * (columns - 1)) / columns)
             property real h: (grid.height / rows) - ((spacing * (rows - 1)) / rows)
 
-            CalcButton { width: grid.w; height: grid.h; operation: "C" }
-            CalcButton { width: grid.w; height: grid.h; operation: CalcEngine.leftArrow }
-            CalcButton { width: grid.w; height: grid.h; operation: CalcEngine.plusminus }
             CalcButton { width: grid.w; height: grid.h; operation: CalcEngine.division; }
-
-
             CalcButton { width: grid.w; height: grid.h; operation: "7"; }
             CalcButton { width: grid.w; height: grid.h; operation: "8"; }
             CalcButton { width: grid.w; height: grid.h; operation: "9"; }
-            CalcButton { width: grid.w; height: grid.h; operation: CalcEngine.multiplication; }
+            CalcButton { width: grid.w; height: grid.h; operation: "-"; }
 
+            CalcButton { width: grid.w; height: grid.h; operation: CalcEngine.multiplication; }
             CalcButton { width: grid.w; height: grid.h; operation: "4"; }
             CalcButton { width: grid.w; height: grid.h; operation: "5"; }
             CalcButton { width: grid.w; height: grid.h; operation: "6"; }
-            CalcButton { width: grid.w; height: grid.h; operation: "-"; }
+            CalcButton { width: grid.w; height: grid.h; operation: "+"; }
 
+            CalcButton { width: grid.w; height: grid.h; operation: "C"  }
             CalcButton { width: grid.w; height: grid.h; operation: "1"; }
             CalcButton { width: grid.w; height: grid.h; operation: "2"; }
             CalcButton { width: grid.w; height: grid.h; operation: "3"; }
-            CalcButton { width: grid.w; height: grid.h; operation: "+"; }
+            CalcButton { width: grid.w; height: grid.h; operation: "="; }
 
+            Text { text: " " }
             CalcButton { width: grid.w; height: grid.h; operation: "."; }
             CalcButton { width: grid.w; height: grid.h; operation: "0"; }
+            CalcButton { width: grid.w; height: grid.h; operation: CalcEngine.leftArrow }
         }
-
-        CalcButton { width: 2*grid.w; height: grid.h; operation: "="; anchors.right: parent.right; anchors.bottom: parent.bottom}
     }
 }
-


### PR DESCRIPTION
Thanks to Allen on Asteroid Matrix Chat for raising following issues, making me look deeper into the calculator app while trying to mitigate them:

- `.` button was hard to reach since very close to the screen edge, partly clipping.
- Button `shades` (pop-ups) clipped for those buttons close to the screen edge.

### Solve issues with the old calculator layout:
- 4x5 column layout was not using the screen estate efficiently (Fig 1)
- `refitText` function had no visible impact on the `displayText` size, long results got clipped on round watches (Fig 1)
- Text buttons where rather small making input hard (Fig 1)
- `displayText` was small font and bold style, making it hard to distinguish from the input buttons (Fig 1)
- `display` area was narrow and not helping to highlight the result (Fig 1)
- Button layout was asymmetric and hard to memorize (Fig 1)
- The `.` button contained in the bottom most row was clipping viewable and touchable area (Fig 1)
- Pop-up button shades had very small text, closed slowly and where coloured in background tone (Fig 2)
- Shades where covered by the finger
- Shades from buttons close to the screen edge where displayed out of viewable area (Fig 3)

### Measures:
- Move to 5x4 layout and adapt `displayBackground` to parent.height / 4 for symmetric display and input area (Fig 1)
- Sort buttons into an easy to memorize pattern (Fig 1)
- Introduce black translucent background for the Display and colourize `displayText` to "Sky blue crayola" with great contrast to the background and matching the new "Paradise Pink" highlight colour of the shades. (Fig 1)
- Colourize shades for better legibility from better contrast to the green background (Fig 2)
- Enlarge button/shade text and move them a bit more away from finger (Fig 2)
- Adapt shade positioning to position of the button, move clipping shades "inwards". (Fig 3)
- Speed up transitions for snappier UX
- Move `calculate.PlusMinus` operation to `onPressed` of the new `displayBackground` `MouseArea`

### Figure 1
https://user-images.githubusercontent.com/15074193/146679605-9945822d-7a85-492a-9275-0d2f254a9488.mp4

### Figure 2
https://user-images.githubusercontent.com/15074193/146680107-f53a30c1-968f-4202-b00b-46f412c2cd56.mp4

### Figure 3
![calculator-shade-mitigate](https://user-images.githubusercontent.com/15074193/146680201-4108bef3-8430-4a3d-bea6-a85963f79c7f.jpg)

I am open for discussions on the colour scheme.
But for now i settled for this one after many trials, though many of the variations i showed on Matrix might still be desirable.
An idea for a feature would be to have a button/MouseArea that switches the colour scheme between 3 to 6 predefined ones and stores the user selection.
This should not block this PR imo, since colouring might need deeper discussion, preferably raised as issues.

Visual changes after commit https://github.com/AsteroidOS/asteroid-calculator/pull/4/commits/9502abf517755ac437b1ce576335bd3bfcb571b0
![calc-001-phthalo](https://user-images.githubusercontent.com/15074193/147288637-a0595772-c265-4ffe-bc1d-4cc25363d2de.jpg)

