### PR TITLE
Move main library file to CMAKE_INSTALL_LIBDIR and add a launch script

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,13 @@ include(AsteroidTranslations)
 
 add_subdirectory(src)
 
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/asteroid-calculator.in
+	${CMAKE_BINARY_DIR}/asteroid-calculator
+	@ONLY)
+
+install(PROGRAMS ${CMAKE_BINARY_DIR}/asteroid-calculator
+	DESTINATION ${CMAKE_INSTALL_BINDIR})
+
 build_translations(i18n)
 generate_desktop(${CMAKE_SOURCE_DIR} asteroid-calculator)
 

--- a/asteroid-calculator.desktop.template
+++ b/asteroid-calculator.desktop.template
@@ -1,7 +1,7 @@
 [Desktop Entry]
 Type=Application
 Categories=Applications;
-Exec=invoker --single-instance --type=qtcomponents-qt5 /usr/bin/asteroid-calculator
+Exec=asteroid-calculator
 Icon=ios-calculator-outline
 X-Asteroid-Center-Color=#7CA600
 X-Asteroid-Outer-Color=#0C0B00

--- a/asteroid-calculator.in
+++ b/asteroid-calculator.in
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+exec invoker --single-instance --type=qtcomponents-qt5 @CMAKE_INSTALL_FULL_LIBDIR@/asteroid-calculator.so

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,8 +1,8 @@
 add_library(asteroid-calculator main.cpp resources.qrc)
-set_target_properties(asteroid-calculator PROPERTIES PREFIX "" SUFFIX "")
+set_target_properties(asteroid-calculator PROPERTIES PREFIX "")
 
 target_link_libraries(asteroid-calculator PUBLIC
 	AsteroidApp)
 
 install(TARGETS asteroid-calculator
-	DESTINATION ${CMAKE_INSTALL_BINDIR})
+	DESTINATION ${CMAKE_INSTALL_LIBDIR})


### PR DESCRIPTION
Previously the main program file was installed to /usr/bin, mistakingly giving the impression it could be executed as is. However it isn't a binary but a library that gets executed through invoker. To prevent confusion move it to /usr/lib and add a launch script to /usr/bin instead which launches it through invoker