### PR TITLE
Rename DeviceInfo to DeviceSpecs to remove conflict

### DIFF
--- a/src/Display.qml
+++ b/src/Display.qml
@@ -29,12 +29,12 @@ Label {
     property int minimumSize: Dims.l(9)
 
     anchors {
-        leftMargin: DeviceInfo.hasRoundScreen ? Dims.w(9) : Dims.w(6)
-        rightMargin: DeviceInfo.hasRoundScreen ? Dims.w(9) : Dims.w(6)
+        leftMargin: DeviceSpecs.hasRoundScreen ? Dims.w(9) : Dims.w(6)
+        rightMargin: DeviceSpecs.hasRoundScreen ? Dims.w(9) : Dims.w(6)
     }
     font.styleName: "ExtraCondensed Medium"
     verticalAlignment: Text.AlignBottom
-    horizontalAlignment: DeviceInfo.hasRoundScreen ? Text.AlignHCenter : Text.AlignRight
+    horizontalAlignment: DeviceSpecs.hasRoundScreen ? Text.AlignHCenter : Text.AlignRight
 
     onDisplayTextLengthChanged: refitText()
     Component.onCompleted: refitText()
@@ -53,7 +53,7 @@ Label {
         return Number(num).toLocaleString(Qt.locale(), 'f', trailing(num))
     }
     function refitText() {
-        if (DeviceInfo.hasRoundScreen) {
+        if (DeviceSpecs.hasRoundScreen) {
             switch (displayTextLength.length) {
                 case 0:
                 case 1:

--- a/src/main.qml
+++ b/src/main.qml
@@ -44,9 +44,9 @@ Application {
 
         anchors {
             fill: parent
-            leftMargin: DeviceInfo.hasRoundScreen ? Dims.w(8) : 0
-            rightMargin: DeviceInfo.hasRoundScreen ? Dims.w(8) : 0
-            bottomMargin: DeviceInfo.hasRoundScreen ? Dims.h(7) : 0
+            leftMargin: DeviceSpecs.hasRoundScreen ? Dims.w(8) : 0
+            rightMargin: DeviceSpecs.hasRoundScreen ? Dims.w(8) : 0
+            bottomMargin: DeviceSpecs.hasRoundScreen ? Dims.h(7) : 0
         }
 
         Item {


### PR DESCRIPTION
This renames the DeviceInfo QML class in org.asteroid.utils to DeviceSpecs to avoid a conflict with an unrelated DeviceInfo class defined in org.nemomobile.systemsettings.

This fixes https://github.com/AsteroidOS/qml-asteroid/issues/56