### PR TITLE
Build-time QML pre-compilation via asteroid_app_qml_module

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,6 +1,12 @@
 add_library(asteroid-calculator main.cpp resources.qrc)
 set_target_properties(asteroid-calculator PROPERTIES PREFIX "")
 
+asteroid_app_qml_module(asteroid-calculator
+	main.qml
+	CalcButton.qml
+	Display.qml
+)
+
 target_link_libraries(
 	asteroid-calculator
 	PRIVATE

--- a/src/resources.qrc
+++ b/src/resources.qrc
@@ -1,8 +1,5 @@
 <RCC>
-    <qresource prefix="/">
-        <file>CalcButton.qml</file>
-        <file>Display.qml</file>
-        <file>main.qml</file>
+    <qresource prefix="/Calculator/">
         <file>calculator.js</file>
     </qresource>
 </RCC>


### PR DESCRIPTION
The .so ships pre-compiled QML bytecode and the engine skips the parse/JIT pipeline on every launch.